### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/assets/javascripts/discourse/initializers/wikimedia.js
+++ b/assets/javascripts/discourse/initializers/wikimedia.js
@@ -1,18 +1,18 @@
-import discourseComputed from "discourse/lib/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default {
   name: "wikimedia",
   initialize() {
     withPluginApi("0.8.23", (api) => {
-      api.modifyClass("controller:preferences/account", {
-        pluginId: "discourse-wikimedia-auth",
-
-        @discourseComputed
-        canUpdateAssociatedAccounts() {
-          return false;
-        },
-      });
+      api.modifyClass(
+        "controller:preferences/account",
+        (Superclass) =>
+          class extends Superclass {
+            get canUpdateAssociatedAccounts() {
+              return false;
+            }
+          }
+      );
     });
   },
 };


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely